### PR TITLE
remove api.github.com support

### DIFF
--- a/content/.htaccess
+++ b/content/.htaccess
@@ -62,9 +62,9 @@ RewriteRule ^japi/([^/]+)/snapshot/(.*)$ https://nightlies.apache.org/pekko/docs
 
 # Security Headers
 Header set Strict-Transport-Security "max-age=31536000"
-# https://github.com/apache/pekko-sbt-paradox/issues/110 is open for https://api.github.com/
-Header set Content-Security-Policy "default-src 'self' https://api.github.com/ https://pekko.apache.org/ ; style-src 'self' https://pekko.apache.org/ 'unsafe-inline' ; script-src 'self' https://pekko.apache.org/ 'unsafe-inline' ; frame-src 'self' ;"
+Header set Content-Security-Policy "default-src 'self' https://pekko.apache.org/ ; style-src 'self' https://pekko.apache.org/ 'unsafe-inline' ; script-src 'self' https://pekko.apache.org/ 'unsafe-inline' ; frame-src 'self' ;"
 Header always set X-Frame-Options SAMEORIGIN
 Header set X-Content-Type-Options nosniff
 Header set X-XSS-Protection "1; mode=block"
 Header set Referrer-Policy: strict-origin
+

--- a/src/main/public/.htaccess
+++ b/src/main/public/.htaccess
@@ -62,9 +62,9 @@ RewriteRule ^japi/([^/]+)/snapshot/(.*)$ https://nightlies.apache.org/pekko/docs
 
 # Security Headers
 Header set Strict-Transport-Security "max-age=31536000"
-# https://github.com/apache/pekko-sbt-paradox/issues/110 is open for https://api.github.com/
-Header set Content-Security-Policy "default-src 'self' https://api.github.com/ https://pekko.apache.org/ ; style-src 'self' https://pekko.apache.org/ 'unsafe-inline' ; script-src 'self' https://pekko.apache.org/ 'unsafe-inline' ; frame-src 'self' ;"
+Header set Content-Security-Policy "default-src 'self' https://pekko.apache.org/ ; style-src 'self' https://pekko.apache.org/ 'unsafe-inline' ; script-src 'self' https://pekko.apache.org/ 'unsafe-inline' ; frame-src 'self' ;"
 Header always set X-Frame-Options SAMEORIGIN
 Header set X-Content-Type-Options nosniff
 Header set X-XSS-Protection "1; mode=block"
 Header set Referrer-Policy: strict-origin
+


### PR DESCRIPTION
No longer needed since we reworked the way the GitHub repos are linked.

See https://github.com/apache/pekko-sbt-paradox/issues/110