### PR TITLE
support 1.1.0 redirects

### DIFF
--- a/content/.htaccess
+++ b/content/.htaccess
@@ -3,10 +3,10 @@ RewriteEngine On
 RewriteRule ^docs/([^/]+)/snapshot/(.*)$ https://nightlies.apache.org/pekko/docs/$1/main-snapshot/docs/$2 [P]
 RewriteRule ^api/([^/]+)/snapshot/(.*)$ https://nightlies.apache.org/pekko/docs/$1/main-snapshot/api/$2 [P]
 RewriteRule ^japi/([^/]+)/snapshot/(.*)$ https://nightlies.apache.org/pekko/docs/$1/main-snapshot/japi/$2 [P]
-# pekko/current gets redirected to pekko/1.0.2
-RewriteRule ^docs/pekko/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko/1.0.2/docs/$1 [P]
-RewriteRule ^api/pekko/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko/1.0.2/api/$1 [P]
-RewriteRule ^japi/pekko/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko/1.0.2/japi/$1 [P]
+# pekko/current gets redirected to pekko/1.0.3
+RewriteRule ^docs/pekko/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko/1.0.3/docs/$1 [P]
+RewriteRule ^api/pekko/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko/1.0.3/api/$1 [P]
+RewriteRule ^japi/pekko/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko/1.0.3/japi/$1 [P]
 # pekko-http/current gets redirected to pekko-http/1.0.1
 RewriteRule ^docs/pekko-http/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-http/1.0.1/docs/$1 [P]
 RewriteRule ^api/pekko-http/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-http/1.0.1/api/$1 [P]
@@ -51,6 +51,14 @@ RewriteRule ^japi/([^/]+)/1.0.1/(.*)$ https://nightlies.apache.org/pekko/docs/$1
 RewriteRule ^docs/([^/]+)/1.0.2/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.0.2/docs/$2 [P]
 RewriteRule ^api/([^/]+)/1.0.2/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.0.2/api/$2 [P]
 RewriteRule ^japi/([^/]+)/1.0.2/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.0.2/japi/$2 [P]
+# 1.0.3 redirect
+RewriteRule ^docs/([^/]+)/1.0.3/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.0.3/docs/$2 [P]
+RewriteRule ^api/([^/]+)/1.0.3/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.0.3/api/$2 [P]
+RewriteRule ^japi/([^/]+)/1.0.3/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.0.3/japi/$2 [P]
+# 1.1.0 redirect
+RewriteRule ^docs/([^/]+)/1.1.0/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.0/docs/$2 [P]
+RewriteRule ^api/([^/]+)/1.1.0/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.0/api/$2 [P]
+RewriteRule ^japi/([^/]+)/1.1.0/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.0/japi/$2 [P]
 # 1.0.3-M1 redirect
 RewriteRule ^docs/([^/]+)/1.0.3-M1/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.0.3-M1/docs/$2 [P]
 RewriteRule ^api/([^/]+)/1.0.3-M1/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.0.3-M1/api/$2 [P]

--- a/src/main/public/.htaccess
+++ b/src/main/public/.htaccess
@@ -3,10 +3,10 @@ RewriteEngine On
 RewriteRule ^docs/([^/]+)/snapshot/(.*)$ https://nightlies.apache.org/pekko/docs/$1/main-snapshot/docs/$2 [P]
 RewriteRule ^api/([^/]+)/snapshot/(.*)$ https://nightlies.apache.org/pekko/docs/$1/main-snapshot/api/$2 [P]
 RewriteRule ^japi/([^/]+)/snapshot/(.*)$ https://nightlies.apache.org/pekko/docs/$1/main-snapshot/japi/$2 [P]
-# pekko/current gets redirected to pekko/1.0.2
-RewriteRule ^docs/pekko/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko/1.0.2/docs/$1 [P]
-RewriteRule ^api/pekko/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko/1.0.2/api/$1 [P]
-RewriteRule ^japi/pekko/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko/1.0.2/japi/$1 [P]
+# pekko/current gets redirected to pekko/1.0.3
+RewriteRule ^docs/pekko/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko/1.0.3/docs/$1 [P]
+RewriteRule ^api/pekko/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko/1.0.3/api/$1 [P]
+RewriteRule ^japi/pekko/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko/1.0.3/japi/$1 [P]
 # pekko-http/current gets redirected to pekko-http/1.0.1
 RewriteRule ^docs/pekko-http/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-http/1.0.1/docs/$1 [P]
 RewriteRule ^api/pekko-http/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-http/1.0.1/api/$1 [P]
@@ -51,6 +51,14 @@ RewriteRule ^japi/([^/]+)/1.0.1/(.*)$ https://nightlies.apache.org/pekko/docs/$1
 RewriteRule ^docs/([^/]+)/1.0.2/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.0.2/docs/$2 [P]
 RewriteRule ^api/([^/]+)/1.0.2/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.0.2/api/$2 [P]
 RewriteRule ^japi/([^/]+)/1.0.2/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.0.2/japi/$2 [P]
+# 1.0.3 redirect
+RewriteRule ^docs/([^/]+)/1.0.3/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.0.3/docs/$2 [P]
+RewriteRule ^api/([^/]+)/1.0.3/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.0.3/api/$2 [P]
+RewriteRule ^japi/([^/]+)/1.0.3/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.0.3/japi/$2 [P]
+# 1.1.0 redirect
+RewriteRule ^docs/([^/]+)/1.1.0/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.0/docs/$2 [P]
+RewriteRule ^api/([^/]+)/1.1.0/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.0/api/$2 [P]
+RewriteRule ^japi/([^/]+)/1.1.0/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.0/japi/$2 [P]
 # 1.0.3-M1 redirect
 RewriteRule ^docs/([^/]+)/1.0.3-M1/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.0.3-M1/docs/$2 [P]
 RewriteRule ^api/([^/]+)/1.0.3-M1/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.0.3-M1/api/$2 [P]


### PR DESCRIPTION
* also, we never set up redirects after the pekko 1.0.3 release
* I plan to redirect 'current' to 1.1.0 when we have more of the major modules with 1.1.0 releases (HTTP, gRPC, Connectors)