### PR TITLE
redirect current to 1.1 for modules with full releases

### DIFF
--- a/content/.htaccess
+++ b/content/.htaccess
@@ -9,10 +9,10 @@ RewriteRule ^docs/pekko/current/project/migration-guides.html https://pekko.apac
 RewriteRule ^docs/pekko/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko/1.1.1/docs/$1 [P]
 RewriteRule ^api/pekko/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko/1.1.1/api/$1 [P]
 RewriteRule ^japi/pekko/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko/1.1.1/japi/$1 [P]
-# pekko-http/current gets redirected to pekko-http/1.0.1
-RewriteRule ^docs/pekko-http/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-http/1.0.1/docs/$1 [P]
-RewriteRule ^api/pekko-http/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-http/1.0.1/api/$1 [P]
-RewriteRule ^japi/pekko-http/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-http/1.0.1/japi/$1 [P]
+# pekko-http/current gets redirected to pekko-http/1.1.0
+RewriteRule ^docs/pekko-http/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-http/1.1.0/docs/$1 [P]
+RewriteRule ^api/pekko-http/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-http/1.1.0/api/$1 [P]
+RewriteRule ^japi/pekko-http/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-http/1.1.0/japi/$1 [P]
 # pekko-management/current gets redirected to pekko-management/1.0.0
 RewriteRule ^docs/pekko-management/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-management/1.0.0/docs/$1 [P]
 RewriteRule ^api/pekko-management/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-management/1.0.0/api/$1 [P]
@@ -22,15 +22,15 @@ RewriteRule ^api/pekko-grpc/current/(.*)$ https://nightlies.apache.org/pekko/doc
 # pekko-connectors/current gets redirected to pekko-connectors/1.0.2
 RewriteRule ^docs/pekko-connectors/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-connectors/1.0.2/docs/$1 [P]
 RewriteRule ^api/pekko-connectors/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-connectors/1.0.2/api/$1 [P]
-# pekko-connectors-kafka/current gets redirected to pekko-connectors-kafka/1.0.0
-RewriteRule ^docs/pekko-connectors-kafka/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-connectors-kafka/1.0.0/docs/$1 [P]
-RewriteRule ^api/pekko-connectors-kafka/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-connectors-kafka/1.0.0/api/$1 [P]
+# pekko-connectors-kafka/current gets redirected to pekko-connectors-kafka/1.1.0
+RewriteRule ^docs/pekko-connectors-kafka/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-connectors-kafka/1.1.0/docs/$1 [P]
+RewriteRule ^api/pekko-connectors-kafka/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-connectors-kafka/1.1.0/api/$1 [P]
 # pekko-persistence-cassandra/current gets redirected to pekko-persistence-cassandra/1.0.0
 RewriteRule ^docs/pekko-persistence-cassandra/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-persistence-cassandra/1.0.0/docs/$1 [P]
 RewriteRule ^api/pekko-persistence-cassandra/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-persistence-cassandra/1.0.0/api/$1 [P]
-# pekko-persistence-jdbc/current gets redirected to pekko-persistence-jdbc/1.0.0
-RewriteRule ^docs/pekko-persistence-jdbc/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-persistence-jdbc/1.0.0/docs/$1 [P]
-RewriteRule ^api/pekko-persistence-jdbc/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-persistence-jdbc/1.0.0/api/$1 [P]
+# pekko-persistence-jdbc/current gets redirected to pekko-persistence-jdbc/1.1.0
+RewriteRule ^docs/pekko-persistence-jdbc/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-persistence-jdbc/1.1.0/docs/$1 [P]
+RewriteRule ^api/pekko-persistence-jdbc/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-persistence-jdbc/1.1.0/api/$1 [P]
 # pekko-persistence-r2dbc/current gets redirected to pekko-persistence-r2dbc/1.0.0
 RewriteRule ^docs/pekko-persistence-r2dbc/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-persistence-r2dbc/1.0.0/docs/$1 [P]
 RewriteRule ^api/pekko-persistence-r2dbc/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-persistence-r2dbc/1.0.0/api/$1 [P]

--- a/src/main/public/.htaccess
+++ b/src/main/public/.htaccess
@@ -9,10 +9,10 @@ RewriteRule ^docs/pekko/current/project/migration-guides.html https://pekko.apac
 RewriteRule ^docs/pekko/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko/1.1.1/docs/$1 [P]
 RewriteRule ^api/pekko/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko/1.1.1/api/$1 [P]
 RewriteRule ^japi/pekko/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko/1.1.1/japi/$1 [P]
-# pekko-http/current gets redirected to pekko-http/1.0.1
-RewriteRule ^docs/pekko-http/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-http/1.0.1/docs/$1 [P]
-RewriteRule ^api/pekko-http/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-http/1.0.1/api/$1 [P]
-RewriteRule ^japi/pekko-http/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-http/1.0.1/japi/$1 [P]
+# pekko-http/current gets redirected to pekko-http/1.1.0
+RewriteRule ^docs/pekko-http/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-http/1.1.0/docs/$1 [P]
+RewriteRule ^api/pekko-http/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-http/1.1.0/api/$1 [P]
+RewriteRule ^japi/pekko-http/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-http/1.1.0/japi/$1 [P]
 # pekko-management/current gets redirected to pekko-management/1.0.0
 RewriteRule ^docs/pekko-management/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-management/1.0.0/docs/$1 [P]
 RewriteRule ^api/pekko-management/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-management/1.0.0/api/$1 [P]
@@ -22,15 +22,15 @@ RewriteRule ^api/pekko-grpc/current/(.*)$ https://nightlies.apache.org/pekko/doc
 # pekko-connectors/current gets redirected to pekko-connectors/1.0.2
 RewriteRule ^docs/pekko-connectors/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-connectors/1.0.2/docs/$1 [P]
 RewriteRule ^api/pekko-connectors/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-connectors/1.0.2/api/$1 [P]
-# pekko-connectors-kafka/current gets redirected to pekko-connectors-kafka/1.0.0
-RewriteRule ^docs/pekko-connectors-kafka/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-connectors-kafka/1.0.0/docs/$1 [P]
-RewriteRule ^api/pekko-connectors-kafka/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-connectors-kafka/1.0.0/api/$1 [P]
+# pekko-connectors-kafka/current gets redirected to pekko-connectors-kafka/1.1.0
+RewriteRule ^docs/pekko-connectors-kafka/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-connectors-kafka/1.1.0/docs/$1 [P]
+RewriteRule ^api/pekko-connectors-kafka/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-connectors-kafka/1.1.0/api/$1 [P]
 # pekko-persistence-cassandra/current gets redirected to pekko-persistence-cassandra/1.0.0
 RewriteRule ^docs/pekko-persistence-cassandra/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-persistence-cassandra/1.0.0/docs/$1 [P]
 RewriteRule ^api/pekko-persistence-cassandra/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-persistence-cassandra/1.0.0/api/$1 [P]
-# pekko-persistence-jdbc/current gets redirected to pekko-persistence-jdbc/1.0.0
-RewriteRule ^docs/pekko-persistence-jdbc/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-persistence-jdbc/1.0.0/docs/$1 [P]
-RewriteRule ^api/pekko-persistence-jdbc/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-persistence-jdbc/1.0.0/api/$1 [P]
+# pekko-persistence-jdbc/current gets redirected to pekko-persistence-jdbc/1.1.0
+RewriteRule ^docs/pekko-persistence-jdbc/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-persistence-jdbc/1.1.0/docs/$1 [P]
+RewriteRule ^api/pekko-persistence-jdbc/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-persistence-jdbc/1.1.0/api/$1 [P]
 # pekko-persistence-r2dbc/current gets redirected to pekko-persistence-r2dbc/1.0.0
 RewriteRule ^docs/pekko-persistence-r2dbc/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-persistence-r2dbc/1.0.0/docs/$1 [P]
 RewriteRule ^api/pekko-persistence-r2dbc/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-persistence-r2dbc/1.0.0/api/$1 [P]


### PR DESCRIPTION
pekko(-core) already has current mapped to 1.1.1