### PR TITLE
change version redirects - including for grpc/current

### DIFF
--- a/content/.htaccess
+++ b/content/.htaccess
@@ -37,6 +37,10 @@ RewriteRule ^api/pekko-persistence-r2dbc/current/(.*)$ https://nightlies.apache.
 # pekko-projection/current gets redirected to pekko-projection/1.0
 RewriteRule ^docs/pekko-projection/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-projection/1.0/docs/$1 [P]
 RewriteRule ^api/pekko-projection/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-projection/1.0/api/$1 [P]
+# pekko-*/current gets redirected to pekko-*/snapshot if no releases exist yet
+RewriteRule ^docs/([^/]+)/current/(.*)$ https://nightlies.apache.org/pekko/docs/$1/main-snapshot/docs/$2 [P]
+RewriteRule ^api/([^/]+)/current/(.*)$ https://nightlies.apache.org/pekko/docs/$1/main-snapshot/api/$2 [P]
+RewriteRule ^japi/([^/]+)/current/(.*)$ https://nightlies.apache.org/pekko/docs/$1/main-snapshot/japi/$2 [P]
 # 1.0 redirect
 RewriteRule ^docs/([^/]+)/1.0/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.0/docs/$2 [P]
 RewriteRule ^api/([^/]+)/1.0/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.0/api/$2 [P]

--- a/content/.htaccess
+++ b/content/.htaccess
@@ -5,42 +5,38 @@ RewriteRule ^api/([^/]+)/snapshot/(.*)$ https://nightlies.apache.org/pekko/docs/
 RewriteRule ^japi/([^/]+)/snapshot/(.*)$ https://nightlies.apache.org/pekko/docs/$1/main-snapshot/japi/$2 [P]
 # broken current links in legacy docs
 RewriteRule ^docs/pekko/current/project/migration-guides.html https://pekko.apache.org/docs/pekko/current/migration/migration-guide-akka-1.0.x.html [P]
-# pekko/current gets redirected to pekko/1.1.1
-RewriteRule ^docs/pekko/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko/1.1.1/docs/$1 [P]
-RewriteRule ^api/pekko/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko/1.1.1/api/$1 [P]
-RewriteRule ^japi/pekko/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko/1.1.1/japi/$1 [P]
-# pekko-http/current gets redirected to pekko-http/1.1.0
-RewriteRule ^docs/pekko-http/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-http/1.1.0/docs/$1 [P]
-RewriteRule ^api/pekko-http/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-http/1.1.0/api/$1 [P]
-RewriteRule ^japi/pekko-http/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-http/1.1.0/japi/$1 [P]
-# pekko-management/current gets redirected to pekko-management/1.0.0
-RewriteRule ^docs/pekko-management/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-management/1.0.0/docs/$1 [P]
-RewriteRule ^api/pekko-management/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-management/1.0.0/api/$1 [P]
-# pekko-grpc/current gets redirected to pekko-grpc/1.0.2
-RewriteRule ^docs/pekko-grpc/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-grpc/1.0.2/docs/$1 [P]
-RewriteRule ^api/pekko-grpc/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-grpc/1.0.2/api/$1 [P]
-# pekko-connectors/current gets redirected to pekko-connectors/1.0.2
-RewriteRule ^docs/pekko-connectors/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-connectors/1.0.2/docs/$1 [P]
-RewriteRule ^api/pekko-connectors/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-connectors/1.0.2/api/$1 [P]
-# pekko-connectors-kafka/current gets redirected to pekko-connectors-kafka/1.1.0
-RewriteRule ^docs/pekko-connectors-kafka/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-connectors-kafka/1.1.0/docs/$1 [P]
-RewriteRule ^api/pekko-connectors-kafka/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-connectors-kafka/1.1.0/api/$1 [P]
-# pekko-persistence-cassandra/current gets redirected to pekko-persistence-cassandra/1.0.0
-RewriteRule ^docs/pekko-persistence-cassandra/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-persistence-cassandra/1.0.0/docs/$1 [P]
-RewriteRule ^api/pekko-persistence-cassandra/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-persistence-cassandra/1.0.0/api/$1 [P]
-# pekko-persistence-jdbc/current gets redirected to pekko-persistence-jdbc/1.1.0
-RewriteRule ^docs/pekko-persistence-jdbc/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-persistence-jdbc/1.1.0/docs/$1 [P]
-RewriteRule ^api/pekko-persistence-jdbc/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-persistence-jdbc/1.1.0/api/$1 [P]
-# pekko-persistence-r2dbc/current gets redirected to pekko-persistence-r2dbc/1.0.0
-RewriteRule ^docs/pekko-persistence-r2dbc/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-persistence-r2dbc/1.0.0/docs/$1 [P]
-RewriteRule ^api/pekko-persistence-r2dbc/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-persistence-r2dbc/1.0.0/api/$1 [P]
-# pekko-projection/current gets redirected to pekko-projection/1.0.0
-RewriteRule ^docs/pekko-projection/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-projection/1.0.0/docs/$1 [P]
-RewriteRule ^api/pekko-projection/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-projection/1.0.0/api/$1 [P]
-# pekko-*/current gets redirected to pekko-*/snapshot if no releases exist yet
-RewriteRule ^docs/([^/]+)/current/(.*)$ https://nightlies.apache.org/pekko/docs/$1/main-snapshot/docs/$2 [P]
-RewriteRule ^api/([^/]+)/current/(.*)$ https://nightlies.apache.org/pekko/docs/$1/main-snapshot/api/$2 [P]
-RewriteRule ^japi/([^/]+)/current/(.*)$ https://nightlies.apache.org/pekko/docs/$1/main-snapshot/japi/$2 [P]
+# pekko/current gets redirected to pekko/1.1
+RewriteRule ^docs/pekko/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko/1.1/docs/$1 [P]
+RewriteRule ^api/pekko/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko/1.1/api/$1 [P]
+RewriteRule ^japi/pekko/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko/1.1/japi/$1 [P]
+# pekko-http/current gets redirected to pekko-http/1.1
+RewriteRule ^docs/pekko-http/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-http/1.1/docs/$1 [P]
+RewriteRule ^api/pekko-http/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-http/1.1/api/$1 [P]
+RewriteRule ^japi/pekko-http/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-http/1.1/japi/$1 [P]
+# pekko-management/current gets redirected to pekko-management/1.0
+RewriteRule ^docs/pekko-management/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-management/1.0/docs/$1 [P]
+RewriteRule ^api/pekko-management/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-management/1.0/api/$1 [P]
+# pekko-grpc/current gets redirected to pekko-grpc/1.1
+RewriteRule ^docs/pekko-grpc/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-grpc/1.1/docs/$1 [P]
+RewriteRule ^api/pekko-grpc/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-grpc/1.1/api/$1 [P]
+# pekko-connectors/current gets redirected to pekko-connectors/1.0
+RewriteRule ^docs/pekko-connectors/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-connectors/1.0/docs/$1 [P]
+RewriteRule ^api/pekko-connectors/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-connectors/1.0/api/$1 [P]
+# pekko-connectors-kafka/current gets redirected to pekko-connectors-kafka/1.1
+RewriteRule ^docs/pekko-connectors-kafka/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-connectors-kafka/1.1/docs/$1 [P]
+RewriteRule ^api/pekko-connectors-kafka/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-connectors-kafka/1.1/api/$1 [P]
+# pekko-persistence-cassandra/current gets redirected to pekko-persistence-cassandra/1.0
+RewriteRule ^docs/pekko-persistence-cassandra/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-persistence-cassandra/1.0/docs/$1 [P]
+RewriteRule ^api/pekko-persistence-cassandra/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-persistence-cassandra/1.0/api/$1 [P]
+# pekko-persistence-jdbc/current gets redirected to pekko-persistence-jdbc/1.1
+RewriteRule ^docs/pekko-persistence-jdbc/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-persistence-jdbc/1.1/docs/$1 [P]
+RewriteRule ^api/pekko-persistence-jdbc/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-persistence-jdbc/1.1/api/$1 [P]
+# pekko-persistence-r2dbc/current gets redirected to pekko-persistence-r2dbc/1.0
+RewriteRule ^docs/pekko-persistence-r2dbc/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-persistence-r2dbc/1.0/docs/$1 [P]
+RewriteRule ^api/pekko-persistence-r2dbc/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-persistence-r2dbc/1.0/api/$1 [P]
+# pekko-projection/current gets redirected to pekko-projection/1.0
+RewriteRule ^docs/pekko-projection/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-projection/1.0/docs/$1 [P]
+RewriteRule ^api/pekko-projection/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-projection/1.0/api/$1 [P]
 # 1.0 redirect
 RewriteRule ^docs/([^/]+)/1.0/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.0/docs/$2 [P]
 RewriteRule ^api/([^/]+)/1.0/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.0/api/$2 [P]
@@ -105,4 +101,3 @@ Header always set X-Frame-Options SAMEORIGIN
 Header set X-Content-Type-Options nosniff
 Header set X-XSS-Protection "1; mode=block"
 Header set Referrer-Policy: strict-origin
-

--- a/src/main/public/.htaccess
+++ b/src/main/public/.htaccess
@@ -37,6 +37,10 @@ RewriteRule ^api/pekko-persistence-r2dbc/current/(.*)$ https://nightlies.apache.
 # pekko-projection/current gets redirected to pekko-projection/1.0
 RewriteRule ^docs/pekko-projection/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-projection/1.0/docs/$1 [P]
 RewriteRule ^api/pekko-projection/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-projection/1.0/api/$1 [P]
+# pekko-*/current gets redirected to pekko-*/snapshot if no releases exist yet
+RewriteRule ^docs/([^/]+)/current/(.*)$ https://nightlies.apache.org/pekko/docs/$1/main-snapshot/docs/$2 [P]
+RewriteRule ^api/([^/]+)/current/(.*)$ https://nightlies.apache.org/pekko/docs/$1/main-snapshot/api/$2 [P]
+RewriteRule ^japi/([^/]+)/current/(.*)$ https://nightlies.apache.org/pekko/docs/$1/main-snapshot/japi/$2 [P]
 # 1.0 redirect
 RewriteRule ^docs/([^/]+)/1.0/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.0/docs/$2 [P]
 RewriteRule ^api/([^/]+)/1.0/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.0/api/$2 [P]

--- a/src/main/public/.htaccess
+++ b/src/main/public/.htaccess
@@ -5,42 +5,38 @@ RewriteRule ^api/([^/]+)/snapshot/(.*)$ https://nightlies.apache.org/pekko/docs/
 RewriteRule ^japi/([^/]+)/snapshot/(.*)$ https://nightlies.apache.org/pekko/docs/$1/main-snapshot/japi/$2 [P]
 # broken current links in legacy docs
 RewriteRule ^docs/pekko/current/project/migration-guides.html https://pekko.apache.org/docs/pekko/current/migration/migration-guide-akka-1.0.x.html [P]
-# pekko/current gets redirected to pekko/1.1.1
-RewriteRule ^docs/pekko/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko/1.1.1/docs/$1 [P]
-RewriteRule ^api/pekko/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko/1.1.1/api/$1 [P]
-RewriteRule ^japi/pekko/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko/1.1.1/japi/$1 [P]
-# pekko-http/current gets redirected to pekko-http/1.1.0
-RewriteRule ^docs/pekko-http/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-http/1.1.0/docs/$1 [P]
-RewriteRule ^api/pekko-http/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-http/1.1.0/api/$1 [P]
-RewriteRule ^japi/pekko-http/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-http/1.1.0/japi/$1 [P]
-# pekko-management/current gets redirected to pekko-management/1.0.0
-RewriteRule ^docs/pekko-management/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-management/1.0.0/docs/$1 [P]
-RewriteRule ^api/pekko-management/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-management/1.0.0/api/$1 [P]
-# pekko-grpc/current gets redirected to pekko-grpc/1.0.2
-RewriteRule ^docs/pekko-grpc/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-grpc/1.0.2/docs/$1 [P]
-RewriteRule ^api/pekko-grpc/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-grpc/1.0.2/api/$1 [P]
-# pekko-connectors/current gets redirected to pekko-connectors/1.0.2
-RewriteRule ^docs/pekko-connectors/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-connectors/1.0.2/docs/$1 [P]
-RewriteRule ^api/pekko-connectors/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-connectors/1.0.2/api/$1 [P]
-# pekko-connectors-kafka/current gets redirected to pekko-connectors-kafka/1.1.0
-RewriteRule ^docs/pekko-connectors-kafka/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-connectors-kafka/1.1.0/docs/$1 [P]
-RewriteRule ^api/pekko-connectors-kafka/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-connectors-kafka/1.1.0/api/$1 [P]
-# pekko-persistence-cassandra/current gets redirected to pekko-persistence-cassandra/1.0.0
-RewriteRule ^docs/pekko-persistence-cassandra/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-persistence-cassandra/1.0.0/docs/$1 [P]
-RewriteRule ^api/pekko-persistence-cassandra/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-persistence-cassandra/1.0.0/api/$1 [P]
-# pekko-persistence-jdbc/current gets redirected to pekko-persistence-jdbc/1.1.0
-RewriteRule ^docs/pekko-persistence-jdbc/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-persistence-jdbc/1.1.0/docs/$1 [P]
-RewriteRule ^api/pekko-persistence-jdbc/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-persistence-jdbc/1.1.0/api/$1 [P]
-# pekko-persistence-r2dbc/current gets redirected to pekko-persistence-r2dbc/1.0.0
-RewriteRule ^docs/pekko-persistence-r2dbc/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-persistence-r2dbc/1.0.0/docs/$1 [P]
-RewriteRule ^api/pekko-persistence-r2dbc/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-persistence-r2dbc/1.0.0/api/$1 [P]
-# pekko-projection/current gets redirected to pekko-projection/1.0.0
-RewriteRule ^docs/pekko-projection/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-projection/1.0.0/docs/$1 [P]
-RewriteRule ^api/pekko-projection/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-projection/1.0.0/api/$1 [P]
-# pekko-*/current gets redirected to pekko-*/snapshot if no releases exist yet
-RewriteRule ^docs/([^/]+)/current/(.*)$ https://nightlies.apache.org/pekko/docs/$1/main-snapshot/docs/$2 [P]
-RewriteRule ^api/([^/]+)/current/(.*)$ https://nightlies.apache.org/pekko/docs/$1/main-snapshot/api/$2 [P]
-RewriteRule ^japi/([^/]+)/current/(.*)$ https://nightlies.apache.org/pekko/docs/$1/main-snapshot/japi/$2 [P]
+# pekko/current gets redirected to pekko/1.1
+RewriteRule ^docs/pekko/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko/1.1/docs/$1 [P]
+RewriteRule ^api/pekko/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko/1.1/api/$1 [P]
+RewriteRule ^japi/pekko/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko/1.1/japi/$1 [P]
+# pekko-http/current gets redirected to pekko-http/1.1
+RewriteRule ^docs/pekko-http/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-http/1.1/docs/$1 [P]
+RewriteRule ^api/pekko-http/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-http/1.1/api/$1 [P]
+RewriteRule ^japi/pekko-http/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-http/1.1/japi/$1 [P]
+# pekko-management/current gets redirected to pekko-management/1.0
+RewriteRule ^docs/pekko-management/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-management/1.0/docs/$1 [P]
+RewriteRule ^api/pekko-management/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-management/1.0/api/$1 [P]
+# pekko-grpc/current gets redirected to pekko-grpc/1.1
+RewriteRule ^docs/pekko-grpc/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-grpc/1.1/docs/$1 [P]
+RewriteRule ^api/pekko-grpc/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-grpc/1.1/api/$1 [P]
+# pekko-connectors/current gets redirected to pekko-connectors/1.0
+RewriteRule ^docs/pekko-connectors/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-connectors/1.0/docs/$1 [P]
+RewriteRule ^api/pekko-connectors/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-connectors/1.0/api/$1 [P]
+# pekko-connectors-kafka/current gets redirected to pekko-connectors-kafka/1.1
+RewriteRule ^docs/pekko-connectors-kafka/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-connectors-kafka/1.1/docs/$1 [P]
+RewriteRule ^api/pekko-connectors-kafka/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-connectors-kafka/1.1/api/$1 [P]
+# pekko-persistence-cassandra/current gets redirected to pekko-persistence-cassandra/1.0
+RewriteRule ^docs/pekko-persistence-cassandra/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-persistence-cassandra/1.0/docs/$1 [P]
+RewriteRule ^api/pekko-persistence-cassandra/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-persistence-cassandra/1.0/api/$1 [P]
+# pekko-persistence-jdbc/current gets redirected to pekko-persistence-jdbc/1.1
+RewriteRule ^docs/pekko-persistence-jdbc/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-persistence-jdbc/1.1/docs/$1 [P]
+RewriteRule ^api/pekko-persistence-jdbc/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-persistence-jdbc/1.1/api/$1 [P]
+# pekko-persistence-r2dbc/current gets redirected to pekko-persistence-r2dbc/1.0
+RewriteRule ^docs/pekko-persistence-r2dbc/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-persistence-r2dbc/1.0/docs/$1 [P]
+RewriteRule ^api/pekko-persistence-r2dbc/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-persistence-r2dbc/1.0/api/$1 [P]
+# pekko-projection/current gets redirected to pekko-projection/1.0
+RewriteRule ^docs/pekko-projection/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-projection/1.0/docs/$1 [P]
+RewriteRule ^api/pekko-projection/current/(.*)$ https://nightlies.apache.org/pekko/docs/pekko-projection/1.0/api/$1 [P]
 # 1.0 redirect
 RewriteRule ^docs/([^/]+)/1.0/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.0/docs/$2 [P]
 RewriteRule ^api/([^/]+)/1.0/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.0/api/$2 [P]
@@ -105,4 +101,3 @@ Header always set X-Frame-Options SAMEORIGIN
 Header set X-Content-Type-Options nosniff
 Header set X-XSS-Protection "1; mode=block"
 Header set Referrer-Policy: strict-origin
-


### PR DESCRIPTION
* grpc 1.1.0 is released
* change all the 'current' redirects to use the x.y docs instead of x.y.z docs because this requires less frequent updating
* x.y.z docs are still there, you just need to specify the x.y.z version in the URL
