### PR TITLE
Remove `profile` from asf-site asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -33,6 +33,5 @@ staging:
   whoami: asf-staging
 
 publish:
-  profile: ~
   whoami: asf-site
 


### PR DESCRIPTION
as it's not / no longer supported for the publish block, only for staging repo's

https://github.com/apache/infrastructure-asfyaml?tab=readme-ov-file#web-site-deployment-service-for-git-repositories