### PR TITLE
redirect 1.1.4 and 1.1.5

### DIFF
--- a/content/.htaccess
+++ b/content/.htaccess
@@ -85,6 +85,14 @@ RewriteRule ^japi/([^/]+)/1.1.2/(.*)$ https://nightlies.apache.org/pekko/docs/$1
 RewriteRule ^docs/([^/]+)/1.1.3/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.3/docs/$2 [P]
 RewriteRule ^api/([^/]+)/1.1.3/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.3/api/$2 [P]
 RewriteRule ^japi/([^/]+)/1.1.3/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.3/japi/$2 [P]
+# 1.1.4 redirect
+RewriteRule ^docs/([^/]+)/1.1.4/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.4/docs/$2 [P]
+RewriteRule ^api/([^/]+)/1.1.4/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.4/api/$2 [P]
+RewriteRule ^japi/([^/]+)/1.1.4/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.4/japi/$2 [P]
+# 1.1.5 redirect
+RewriteRule ^docs/([^/]+)/1.1.5/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.5/docs/$2 [P]
+RewriteRule ^api/([^/]+)/1.1.5/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.5/api/$2 [P]
+RewriteRule ^japi/([^/]+)/1.1.5/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.5/japi/$2 [P]
 # 1.0.3-M1 redirect
 RewriteRule ^docs/([^/]+)/1.0.3-M1/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.0.3-M1/docs/$2 [P]
 RewriteRule ^api/([^/]+)/1.0.3-M1/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.0.3-M1/api/$2 [P]

--- a/src/main/public/.htaccess
+++ b/src/main/public/.htaccess
@@ -85,6 +85,14 @@ RewriteRule ^japi/([^/]+)/1.1.2/(.*)$ https://nightlies.apache.org/pekko/docs/$1
 RewriteRule ^docs/([^/]+)/1.1.3/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.3/docs/$2 [P]
 RewriteRule ^api/([^/]+)/1.1.3/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.3/api/$2 [P]
 RewriteRule ^japi/([^/]+)/1.1.3/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.3/japi/$2 [P]
+# 1.1.4 redirect
+RewriteRule ^docs/([^/]+)/1.1.4/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.4/docs/$2 [P]
+RewriteRule ^api/([^/]+)/1.1.4/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.4/api/$2 [P]
+RewriteRule ^japi/([^/]+)/1.1.4/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.4/japi/$2 [P]
+# 1.1.5 redirect
+RewriteRule ^docs/([^/]+)/1.1.5/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.5/docs/$2 [P]
+RewriteRule ^api/([^/]+)/1.1.5/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.5/api/$2 [P]
+RewriteRule ^japi/([^/]+)/1.1.5/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.5/japi/$2 [P]
 # 1.0.3-M1 redirect
 RewriteRule ^docs/([^/]+)/1.0.3-M1/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.0.3-M1/docs/$2 [P]
 RewriteRule ^api/([^/]+)/1.0.3-M1/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.0.3-M1/api/$2 [P]


### PR DESCRIPTION
* needed to allow 1.1.4 docs to be accessed on pekko.apache.org
* add 1.1.5 redirect too (forward planning)
