### PR TITLE
redirect 1.2.0 (and some other versions)

### DIFF
--- a/content/.htaccess
+++ b/content/.htaccess
@@ -102,17 +102,17 @@ RewriteRule ^docs/([^/]+)/1.1.5/(.*)$ https://nightlies.apache.org/pekko/docs/$1
 RewriteRule ^api/([^/]+)/1.1.5/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.5/api/$2 [P]
 RewriteRule ^japi/([^/]+)/1.1.5/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.5/japi/$2 [P]
 # 1.1.6 redirect
-RewriteRule ^docs/([^/]+)/1.1.6/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.5/docs/$2 [P]
-RewriteRule ^api/([^/]+)/1.1.6/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.5/api/$2 [P]
-RewriteRule ^japi/([^/]+)/1.1.6/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.5/japi/$2 [P]
+RewriteRule ^docs/([^/]+)/1.1.6/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.6/docs/$2 [P]
+RewriteRule ^api/([^/]+)/1.1.6/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.6/api/$2 [P]
+RewriteRule ^japi/([^/]+)/1.1.6/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.6/japi/$2 [P]
 # 1.2.0 redirect
-RewriteRule ^docs/([^/]+)/1.2.0/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.5/docs/$2 [P]
-RewriteRule ^api/([^/]+)/1.2.0/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.5/api/$2 [P]
-RewriteRule ^japi/([^/]+)/1.2.0/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.5/japi/$2 [P]
+RewriteRule ^docs/([^/]+)/1.2.0/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.2.0/docs/$2 [P]
+RewriteRule ^api/([^/]+)/1.2.0/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.2.0/api/$2 [P]
+RewriteRule ^japi/([^/]+)/1.2.0/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.2.0/japi/$2 [P]
 # 1.2.1 redirect
-RewriteRule ^docs/([^/]+)/1.2.1/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.5/docs/$2 [P]
-RewriteRule ^api/([^/]+)/1.2.1/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.5/api/$2 [P]
-RewriteRule ^japi/([^/]+)/1.2.1/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.5/japi/$2 [P]
+RewriteRule ^docs/([^/]+)/1.2.1/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.2.1/docs/$2 [P]
+RewriteRule ^api/([^/]+)/1.2.1/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.2.1/api/$2 [P]
+RewriteRule ^japi/([^/]+)/1.2.1/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.2.1/japi/$2 [P]
 # 1.0.3-M1 redirect
 RewriteRule ^docs/([^/]+)/1.0.3-M1/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.0.3-M1/docs/$2 [P]
 RewriteRule ^api/([^/]+)/1.0.3-M1/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.0.3-M1/api/$2 [P]

--- a/src/main/public/.htaccess
+++ b/src/main/public/.htaccess
@@ -102,17 +102,17 @@ RewriteRule ^docs/([^/]+)/1.1.5/(.*)$ https://nightlies.apache.org/pekko/docs/$1
 RewriteRule ^api/([^/]+)/1.1.5/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.5/api/$2 [P]
 RewriteRule ^japi/([^/]+)/1.1.5/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.5/japi/$2 [P]
 # 1.1.6 redirect
-RewriteRule ^docs/([^/]+)/1.1.6/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.5/docs/$2 [P]
-RewriteRule ^api/([^/]+)/1.1.6/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.5/api/$2 [P]
-RewriteRule ^japi/([^/]+)/1.1.6/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.5/japi/$2 [P]
+RewriteRule ^docs/([^/]+)/1.1.6/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.6/docs/$2 [P]
+RewriteRule ^api/([^/]+)/1.1.6/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.6/api/$2 [P]
+RewriteRule ^japi/([^/]+)/1.1.6/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.6/japi/$2 [P]
 # 1.2.0 redirect
-RewriteRule ^docs/([^/]+)/1.2.0/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.5/docs/$2 [P]
-RewriteRule ^api/([^/]+)/1.2.0/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.5/api/$2 [P]
-RewriteRule ^japi/([^/]+)/1.2.0/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.5/japi/$2 [P]
+RewriteRule ^docs/([^/]+)/1.2.0/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.2.0/docs/$2 [P]
+RewriteRule ^api/([^/]+)/1.2.0/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.2.0/api/$2 [P]
+RewriteRule ^japi/([^/]+)/1.2.0/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.2.0/japi/$2 [P]
 # 1.2.1 redirect
-RewriteRule ^docs/([^/]+)/1.2.1/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.5/docs/$2 [P]
-RewriteRule ^api/([^/]+)/1.2.1/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.5/api/$2 [P]
-RewriteRule ^japi/([^/]+)/1.2.1/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.1.5/japi/$2 [P]
+RewriteRule ^docs/([^/]+)/1.2.1/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.2.1/docs/$2 [P]
+RewriteRule ^api/([^/]+)/1.2.1/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.2.1/api/$2 [P]
+RewriteRule ^japi/([^/]+)/1.2.1/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.2.1/japi/$2 [P]
 # 1.0.3-M1 redirect
 RewriteRule ^docs/([^/]+)/1.0.3-M1/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.0.3-M1/docs/$2 [P]
 RewriteRule ^api/([^/]+)/1.0.3-M1/(.*)$ https://nightlies.apache.org/pekko/docs/$1/1.0.3-M1/api/$2 [P]


### PR DESCRIPTION
* 1.2.0 and some expected future releases - redirect the links so that we can pick up the docs from nightlies.apache.org
* breaking some link validation builds 