### PR TITLE
chore: pin sbt to 1.x

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,4 @@
+updates.pin = [
+  # blocked on https://github.com/apache/pekko-sbt-paradox/issues/182
+  { groupId = "org.scala-sbt", artifactId = "sbt", version = "1." }
+]


### PR DESCRIPTION
until https://github.com/apache/pekko-sbt-paradox/issues/182

replaces #219 